### PR TITLE
Add preview field and retrieve song by pairing code endpoint

### DIFF
--- a/src/main/java/com/lessmatch/lessmatch/api/controller/SongController.java
+++ b/src/main/java/com/lessmatch/lessmatch/api/controller/SongController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,5 +34,11 @@ public class SongController {
     public ResponseEntity<SongBasicInfo> create(@Validated @RequestBody SongRequest request) {
         SongBasicInfo songResponse = this.songService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(songResponse);
+    }
+
+    @GetMapping("/getByParing/{code}")
+    public ResponseEntity<SongBasicInfo> getByCode(@PathVariable String code) {
+        SongBasicInfo songResponse = this.songService.findByCode(code);
+        return ResponseEntity.ok(songResponse);
     }
 }

--- a/src/main/java/com/lessmatch/lessmatch/api/dto/SongBasicInfo.java
+++ b/src/main/java/com/lessmatch/lessmatch/api/dto/SongBasicInfo.java
@@ -14,6 +14,7 @@ public class SongBasicInfo {
     private Long id;
     private String title;
     private String artist;
+    private String preview;
     private String albumImage;
     private int verseCount;
     private String lyricsApiUrl;

--- a/src/main/java/com/lessmatch/lessmatch/api/dto/request/SongRequest.java
+++ b/src/main/java/com/lessmatch/lessmatch/api/dto/request/SongRequest.java
@@ -24,10 +24,15 @@ public class SongRequest {
     @NotBlank(message = "Song title is required")
     @Size(max = 120, message = "Title must not exceed 120 characters")
     private String title;
+
     
     @NotBlank(message = "Artist name is required")
     @Size(max = 120, message = "Artist name must not exceed 120 characters")
     private String artist;
+    
+    @NotBlank(message = "Preview text is required")
+    @Size(max = 500, message = "Preview text must not exceed 500 characters")
+    private String preview;
     
     @URL(message = "Album image URL must be valid")
     @Size(max = 250, message = "Album image URL must not exceed 250 characters")

--- a/src/main/java/com/lessmatch/lessmatch/config/CorsConfig.java
+++ b/src/main/java/com/lessmatch/lessmatch/config/CorsConfig.java
@@ -11,7 +11,7 @@ public class CorsConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:5173")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);
     }

--- a/src/main/java/com/lessmatch/lessmatch/domain/entity/Song.java
+++ b/src/main/java/com/lessmatch/lessmatch/domain/entity/Song.java
@@ -30,6 +30,9 @@ public class Song {
     
     @Column(nullable = false)
     private String artist;
+
+    @Column(nullable = false, length = 500, columnDefinition = "TEXT")
+    private String preview;
     
     @Column(nullable = false)
     private String albumImage;

--- a/src/main/java/com/lessmatch/lessmatch/domain/repo/SongRepo.java
+++ b/src/main/java/com/lessmatch/lessmatch/domain/repo/SongRepo.java
@@ -13,4 +13,6 @@ public interface SongRepo extends JpaRepository<Song,Long>{
     List<Song> findMostPopularSongs();
 
     Optional<Song> findByTitleAndArtist(String title, String artist);
+
+    Song findByPairingsPairingCode(String pairingCode);
 }

--- a/src/main/java/com/lessmatch/lessmatch/infrastructure/abstract_service/ISongService.java
+++ b/src/main/java/com/lessmatch/lessmatch/infrastructure/abstract_service/ISongService.java
@@ -7,4 +7,5 @@ import com.lessmatch.lessmatch.api.dto.request.SongRequest;
 
 public interface ISongService extends CrudService<SongRequest, SongBasicInfo, Long>{
     List<SongBasicInfo> getMostPopularSongs();
+    SongBasicInfo findByCode(String code);
 }

--- a/src/main/java/com/lessmatch/lessmatch/infrastructure/service/SongService.java
+++ b/src/main/java/com/lessmatch/lessmatch/infrastructure/service/SongService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.lessmatch.lessmatch.api.dto.SongBasicInfo;
 import com.lessmatch.lessmatch.api.dto.request.SongRequest;
 import com.lessmatch.lessmatch.api.error.IdNotFoundException;
+import com.lessmatch.lessmatch.api.error.InvalidRequestException;
 import com.lessmatch.lessmatch.domain.entity.Song;
 import com.lessmatch.lessmatch.domain.repo.SongRepo;
 import com.lessmatch.lessmatch.infrastructure.abstract_service.ISongService;
@@ -30,6 +31,16 @@ public class SongService implements ISongService {
                 Song newSong = songMapper.toEntity(songRequest);
                 return songRepository.save(newSong);
             });
+    }
+
+    @Override
+    public SongBasicInfo findByCode(String code) {
+
+        Song song = songRepository.findByPairingsPairingCode(code);
+        if (song == null) {
+            throw new InvalidRequestException("No song found for pairing code: " + code);
+        }
+        return songMapper.toResponse(song);
     }
 
     @Override


### PR DESCRIPTION
Introduce a preview field in the Song DTOs and update validation rules accordingly. Add a new endpoint to retrieve a song using its pairing code, enhancing the API functionality. Update CORS allowed methods to include PATCH.